### PR TITLE
docs: fix broken path reference to persona-generator package

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 The persona-generator is a library designed to transform user input (natural language processing) into structured JSON files representing AI agent personas. It converts user friendly descriptions into detailed character profiles, including secrets, biographical information, lore, and knowledge topics, an utility for building AI-driven apps.
 
-You'll find the project located in [packages/persona-generator](./packages/personage-generator), alongside there's the service built as lambda [packages/persona-generator-service](packages/persona-generator-service).
+You'll find the project located in [packages/persona-generator](./packages/persona-generator), alongside there's the service built as lambda [packages/persona-generator-service](packages/persona-generator-service).
 
 ## Overview
 


### PR DESCRIPTION
## Why?

noticed a typo in the markdown link — it was pointing to `personage-generator` instead of `persona-generator`.
fixed the path so it now correctly links to the intended package directory.

## Contribution checklist?

- [ ] The commit messages are detailed
- [ ] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] Document filename is named after the slug
- [ ] You've reviewed spelling using a grammar checker
- [x] For documentation, guides or references, you've tested the commands and steps
- [ ] You've done enough research before writing

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The Components are escaping output (to prevent XSS)

## References?

Optionally, provide references such as links

## Preview?

Optionally, provide the preview url here
