### PR TITLE
fix: wrong parameter usage in `cfn-lint`

### DIFF
--- a/scripts/dev-lint-serverless
+++ b/scripts/dev-lint-serverless
@@ -4,7 +4,7 @@ echo "🕵️ Validate infra template against recommended AWS practices..."
 
 serverlessRules="cfn_lint_serverless.rules"
 
-if ! cfn-lint template.yaml -a "$serverlessRules"; then
+if ! cfn-lint --rules "$serverlessRules" template.yaml; then
   echo "🚑 Found some issues!"
 
   exit 1


### PR DESCRIPTION
## Why?

fixed an issue where the `-a` parameter was incorrectly used for specifying custom rules in `cfn-lint`.

the correct parameters are `--rules` or `--rulesdir`, which are now properly applied to point to custom rules files.

## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] Document filename is named after the slug
- [x] You've reviewed spelling using a grammar checker
- [ ] For documentation, guides or references, you've tested the commands and steps
- [x] You've done enough research before writing

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The Components are escaping output (to prevent XSS)
